### PR TITLE
refactor: simplify tui, events, errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "strum 0.26.1",
  "textwrap",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "tracing",
@@ -2815,6 +2816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "crates-tui"
 version = "0.1.0"
 edition = "2021"
 description = "A TUI for crates.io"
-repository = "https://github.com/kdheepak/crates-tui"
-authors = ["Dheepak Krishnamurthy <me@kdheepak.com>"]
+repository = "https://github.com/ratatui-org/crates-tui"
+authors = ["The Ratatui Developers"]
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -39,7 +39,8 @@ signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }
 textwrap = "0.16.0"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.36.0", features = ["full"] }
+tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 toml = "0.8.8"
 tracing = "0.1.40"

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,10 +161,12 @@ impl App {
         }
     }
 
-    /// The main 'run' function delegates to the two functions below,
-    /// to handle TUI events and App actions respectively.
+    /// Runs the main loop of the application, handling events and actions
     pub async fn run(&mut self, mut tui: Tui) -> Result<()> {
-        tui.enter()?;
+        // uncomment to test error handling
+        // panic!("test panic");
+        // Err(color_eyre::eyre::eyre!("Error"))?;
+
         loop {
             if let Some(e) = tui.next().await {
                 self.handle_tui_event(e)?.map(|action| self.tx.send(action));
@@ -177,7 +179,6 @@ impl App {
                 break;
             }
         }
-        tui.exit()?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let tui = tui::Tui::new()?;
+    let tui = tui::Tui::init()?;
     App::new().run(tui).await?;
 
     Ok(())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,26 +1,21 @@
 use std::{
+    io::{stdout, Stdout},
     ops::{Deref, DerefMut},
+    pin::Pin,
     time::Duration,
 };
 
 use color_eyre::eyre::Result;
 use crossterm::{
-    cursor,
-    event::{
-        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event as CrosstermEvent, KeyEvent, KeyEventKind, MouseEvent,
-    },
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
+    event::{Event as CrosstermEvent, *},
+    execute,
+    terminal::*,
 };
-use futures::{FutureExt, StreamExt};
-use ratatui::backend::CrosstermBackend as Backend;
+use futures::{Stream, StreamExt};
+use ratatui::prelude::*;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    task::JoinHandle,
-};
-use tokio_util::sync::CancellationToken;
-use tracing::error;
+use tokio::time::interval;
+use tokio_stream::{wrappers::IntervalStream, StreamMap};
 
 use crate::config;
 
@@ -41,227 +36,102 @@ pub enum Event {
     Resize(u16, u16),
 }
 
-// FIXME: this struct seems like it's doing a lot of different things. It's a
-// terminal, a task, a cancellation token, and a channel all in one. It's also a
-// bit of a kitchen sink in terms of configuration options. (CoPilot completed
-// that, but it's a good point.)
 pub struct Tui {
-    pub terminal: ratatui::Terminal<Backend<std::io::Stdout>>,
-    pub task: JoinHandle<()>,
-    pub cancellation_token: CancellationToken,
-    pub event_rx: UnboundedReceiver<Event>,
-    pub event_tx: UnboundedSender<Event>,
-    pub frame_rate: f64,
-    pub tick_rate: f64,
-    pub key_refresh_rate: f64,
-    pub mouse: bool,
-    pub paste: bool,
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+    streams: StreamMap<String, Pin<Box<dyn Stream<Item = Event>>>>,
 }
 
 impl Tui {
-    pub fn new() -> Result<Self> {
-        let tick_rate = config::get().tick_rate;
-        let frame_rate = config::get().frame_rate;
-        let key_refresh_rate = config::get().key_refresh_rate;
-        let mouse = config::get().enable_mouse;
-        let paste = config::get().enable_paste;
-        let terminal = ratatui::Terminal::new(Backend::new(std::io::stdout()))?;
-        let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let cancellation_token = CancellationToken::new();
-        let task = tokio::spawn(async {});
-        Ok(Self {
-            terminal,
-            task,
-            cancellation_token,
-            event_rx,
-            event_tx,
-            frame_rate,
-            tick_rate,
-            key_refresh_rate,
-            mouse,
-            paste,
-        })
-    }
-
-    // FIXME: a lot of unused methods here. I think we should remove them and then
-    // add them back as we need them.
-    #[allow(unused)]
-    pub fn tick_rate(mut self, tick_rate: f64) -> Self {
-        self.tick_rate = tick_rate;
-        self
-    }
-
-    #[allow(unused)]
-    pub fn frame_rate(mut self, frame_rate: f64) -> Self {
-        self.frame_rate = frame_rate;
-        self
-    }
-
-    #[allow(unused)]
-    pub fn mouse(mut self, mouse: bool) -> Self {
-        self.mouse = mouse;
-        self
-    }
-
-    #[allow(unused)]
-    pub fn paste(mut self, paste: bool) -> Self {
-        self.paste = paste;
-        self
-    }
-
-    // FIXME: the nesting in this method is a bit hard to follow. It's also doing a
-    // lot of different things. Looking at this you have to understand the whole
-    // thing to understand any part of it.
-    pub fn start(&mut self) {
-        let tick_delay = std::time::Duration::from_secs_f64(1.0 / self.tick_rate);
-        let key_refresh_delay = std::time::Duration::from_secs_f64(1.0 / self.key_refresh_rate);
-        let render_delay = std::time::Duration::from_secs_f64(1.0 / self.frame_rate);
-        self.cancel();
-        self.cancellation_token = CancellationToken::new();
-        let _cancellation_token = self.cancellation_token.clone();
-        let _event_tx = self.event_tx.clone();
-        self.task = tokio::spawn(async move {
-            let mut reader = crossterm::event::EventStream::new();
-            let mut tick_interval = tokio::time::interval(tick_delay);
-            let mut key_refresh_interval = tokio::time::interval(key_refresh_delay);
-            let mut render_interval = tokio::time::interval(render_delay);
-            _event_tx.send(Event::Init).unwrap();
-            loop {
-                let tick_delay = tick_interval.tick();
-                let key_refresh_delay = key_refresh_interval.tick();
-                let render_delay = render_interval.tick();
-                let crossterm_event = reader.next().fuse();
-                // FIXME: use small composable tasks rather than large select blocks like this
-                // to make this easier to read
-                tokio::select! {
-                  _ = _cancellation_token.cancelled() => {
-                    break;
-                  }
-                  maybe_event = crossterm_event => {
-                    match maybe_event {
-                      Some(Ok(evt)) => {
-                        match evt {
-                            // FIXME: convert and then send
-                          CrosstermEvent::Key(key) => {
-                            if key.kind == KeyEventKind::Press {
-                              _event_tx.send(Event::Key(key)).unwrap();
-                            }
-                          },
-                          CrosstermEvent::Mouse(mouse) => {
-                            _event_tx.send(Event::Mouse(mouse)).unwrap();
-                          },
-                          CrosstermEvent::Resize(x, y) => {
-                            _event_tx.send(Event::Resize(x, y)).unwrap();
-                          },
-                          CrosstermEvent::FocusLost => {
-                            _event_tx.send(Event::FocusLost).unwrap();
-                          },
-                          CrosstermEvent::FocusGained => {
-                            _event_tx.send(Event::FocusGained).unwrap();
-                          },
-                          CrosstermEvent::Paste(s) => {
-                            _event_tx.send(Event::Paste(s)).unwrap();
-                          },
-                        }
-                      }
-                      Some(Err(_)) => {
-                        _event_tx.send(Event::Error).unwrap();
-                      }
-                      None => {},
-                    }
-                  },
-                  _ = tick_delay => {
-                      _event_tx.send(Event::Tick).unwrap();
-                  },
-                  _ = key_refresh_delay => {
-                      _event_tx.send(Event::KeyRefresh).unwrap();
-                  },
-                  _ = render_delay => {
-                      _event_tx.send(Event::Render).unwrap();
-                  },
-                }
-            }
-        });
-    }
-
-    pub fn stop(&self) -> Result<()> {
-        self.cancel();
-        // FIXME: use intention revealing names - retry_count or something
-        // add a comment explaining why we're doing this
-        let mut retry_count = 0;
-
-        while !self.task.is_finished() {
-            std::thread::sleep(Duration::from_millis(1));
-            retry_count += 1;
-            // FIXME: are we really calling this 50 times? That seems like a lot.
-            if retry_count > 50 {
-                self.task.abort();
-            }
-            if retry_count > 100 {
-                error!("Failed to abort task in 100 milliseconds for unknown reason");
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    /// the crossterm:: stuff makes this harder to read
-    /// init() or init_terminal is a better name
-    pub fn enter(&mut self) -> Result<()> {
-        crossterm::terminal::enable_raw_mode()?;
-        crossterm::execute!(std::io::stdout(), EnterAlternateScreen, cursor::Hide)?;
-        if self.mouse {
-            crossterm::execute!(std::io::stdout(), EnableMouseCapture)?;
-        }
-        if self.paste {
-            crossterm::execute!(std::io::stdout(), EnableBracketedPaste)?;
-        }
-        self.start();
-        Ok(())
-    }
-
-    pub fn exit(&mut self) -> Result<()> {
-        self.stop()?;
-        if crossterm::terminal::is_raw_mode_enabled()? {
-            self.flush()?;
-            if self.paste {
-                crossterm::execute!(std::io::stdout(), DisableBracketedPaste)?;
-            }
-            if self.mouse {
-                crossterm::execute!(std::io::stdout(), DisableMouseCapture)?;
-            }
-            crossterm::execute!(std::io::stdout(), LeaveAlternateScreen, cursor::Show)?;
-            crossterm::terminal::disable_raw_mode()?;
-        }
-        Ok(())
-    }
-
-    pub fn cancel(&self) {
-        self.cancellation_token.cancel();
-    }
-
-    // FIXME: comment this
-    #[allow(unused)]
-    pub fn suspend(&mut self) -> Result<()> {
-        self.exit()?;
-        #[cfg(not(windows))]
-        signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP)?;
-        Ok(())
-    }
-
-    #[allow(unused)]
-    pub fn resume(&mut self) -> Result<()> {
-        self.enter()?;
-        Ok(())
+    pub fn init() -> Result<Self> {
+        let backend = init_backend()?;
+        let mut terminal = Terminal::new(backend)?;
+        terminal.clear()?;
+        terminal.hide_cursor()?;
+        let streams = create_streams();
+        Ok(Self { terminal, streams })
     }
 
     pub async fn next(&mut self) -> Option<Event> {
-        self.event_rx.recv().await
+        match self.streams.next().await {
+            Some((_name, event)) => Some(event),
+            None => None,
+        }
     }
 }
 
+fn init_backend() -> Result<CrosstermBackend<Stdout>> {
+    let backend = CrosstermBackend::new(stdout());
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen)?;
+    if config::get().enable_mouse {
+        execute!(stdout(), EnableMouseCapture)?;
+    }
+    if config::get().enable_paste {
+        execute!(stdout(), EnableBracketedPaste)?;
+    }
+    Ok(backend)
+}
+
+pub fn restore_backend() -> Result<()> {
+    if config::get().enable_mouse {
+        execute!(stdout(), DisableBracketedPaste)?;
+    }
+    if config::get().enable_mouse {
+        execute!(stdout(), DisableMouseCapture)?;
+    }
+    execute!(stdout(), LeaveAlternateScreen)?;
+    disable_raw_mode()?;
+    Ok(())
+}
+
+fn create_streams() -> StreamMap<String, Pin<Box<dyn Stream<Item = Event>>>> {
+    StreamMap::from_iter([
+        ("ticks".to_string(), tick_stream()),
+        ("key_refresh".to_string(), key_refresh_stream()),
+        ("render".to_string(), render_stream()),
+        ("crossterm".to_string(), crossterm_stream()),
+    ])
+}
+
+fn tick_stream() -> Pin<Box<dyn Stream<Item = Event>>> {
+    let tick_delay = Duration::from_secs_f64(1.0 / config::get().tick_rate);
+    let tick_interval = interval(tick_delay);
+    Box::pin(IntervalStream::new(tick_interval).map(|_| Event::Tick))
+}
+
+fn key_refresh_stream() -> Pin<Box<dyn Stream<Item = Event>>> {
+    let key_refresh_delay = Duration::from_secs_f64(1.0 / config::get().key_refresh_rate);
+    let key_refresh_interval = interval(key_refresh_delay);
+    Box::pin(IntervalStream::new(key_refresh_interval).map(|_| Event::KeyRefresh))
+}
+
+fn render_stream() -> Pin<Box<dyn Stream<Item = Event>>> {
+    let render_delay = Duration::from_secs_f64(1.0 / config::get().frame_rate);
+    let render_interval = interval(render_delay);
+    Box::pin(IntervalStream::new(render_interval).map(|_| Event::Render))
+}
+
+fn crossterm_stream() -> Pin<Box<dyn Stream<Item = Event>>> {
+    Box::pin(EventStream::new().fuse().filter_map(|event| async move {
+        match event {
+            Ok(event) => match event {
+                CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                    Some(Event::Key(key))
+                }
+                CrosstermEvent::Mouse(mouse) => Some(Event::Mouse(mouse)),
+                CrosstermEvent::Resize(x, y) => Some(Event::Resize(x, y)),
+                CrosstermEvent::FocusLost => Some(Event::FocusLost),
+                CrosstermEvent::FocusGained => Some(Event::FocusGained),
+                CrosstermEvent::Paste(s) => Some(Event::Paste(s)),
+                _ => None,
+            },
+            Err(_) => Some(Event::Error),
+        }
+    }))
+}
+
 impl Deref for Tui {
-    type Target = ratatui::Terminal<Backend<std::io::Stdout>>;
+    type Target = Terminal<CrosstermBackend<Stdout>>;
 
     fn deref(&self) -> &Self::Target {
         &self.terminal
@@ -276,6 +146,6 @@ impl DerefMut for Tui {
 
 impl Drop for Tui {
     fn drop(&mut self) {
-        self.exit().unwrap();
+        restore_backend().unwrap();
     }
 }


### PR DESCRIPTION
- Remove unused methods from Tui
- Use tokio streams instead of task + channel
- Simplify error handling and panic hooks setup
- TODO - work out how to log the panic message
  properly (had borrow check issues in the
  color_eyre panic hook for that)
