### PR TITLE
refactor: use cfg_if crate for better cfg checks

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,3 @@
 reorder_imports = true
 use_field_init_shorthand = true
 use_try_shorthand = true
-wrap_comments = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ name = "crates-tui"
 version = "0.1.0"
 dependencies = [
  "better-panic",
+ "cfg-if",
  "chrono",
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 # simplifications in the code.
 
 better-panic = "0.3.0"
+cfg-if = "1.0.0"
 chrono = "0.4.31"
 clap = { version = "4.4.11", features = ["derive", "cargo", "wrap_help", "unicode", "string", "unstable-styles", "color"] }
 color-eyre = "0.6.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,6 +7,7 @@ use color_eyre::{
 use tracing::error;
 
 use crate::tui;
+use cfg_if::cfg_if;
 
 pub fn install_hooks() -> Result<()> {
     let (panic_hook, eyre_hook) = HookBuilder::default()
@@ -19,11 +20,13 @@ pub fn install_hooks() -> Result<()> {
         .display_env_section(false)
         .into_hooks();
 
-    #[cfg(debug_assertions)]
-    install_better_panic();
-    #[cfg(not(debug_assertions))]
-    install_human_panic();
-
+    cfg_if! {
+        if #[cfg(debug_assertions)] {
+            install_better_panic();
+        } else {
+            install_human_panic();
+        }
+    }
     install_color_eyre_panic_hook(panic_hook);
     install_eyre_hook(eyre_hook)?;
 


### PR DESCRIPTION
VSCode shows one side of the cfg as unused all the time, annoyingly
