### PR TITLE
refactor: simplify popup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -229,9 +229,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "bytes"
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -360,14 +360,14 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
  "terminal_size",
  "unicase",
  "unicode-width",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
@@ -675,7 +675,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -1567,9 +1567,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -1797,9 +1797,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -2662,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64",
  "chrono",
@@ -2672,6 +2672,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -2679,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2781,9 +2782,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
+checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
  "bitflags 2.4.2",
  "calloop",
@@ -2855,6 +2856,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -2951,13 +2958,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3128,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3149,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -3332,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -3454,9 +3460,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3464,9 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -3479,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3491,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3501,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3514,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wayland-backend"
@@ -3616,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3881,9 +3887,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ use crate::{
     widgets::{
         crate_info_table::CrateInfoTableWidget,
         help::{Help, HelpWidget},
-        popup_message::{Popup, PopupMessageWidget},
+        popup_message::{PopupMessageState, PopupMessageWidget},
         search_filter_prompt::{SearchFilterPrompt, SearchFilterPromptWidget},
         search_results_table::{SearchResultsTable, SearchResultsTableWidget},
         summary::{Summary, SummaryWidget},
@@ -152,17 +152,8 @@ pub struct App {
     /// within the terminal UI.
     search_results: SearchResultsTable,
 
-    /// An optional error message that, when set, should be shown to the user,
-    /// in the form of a popup.
-    error_message: Option<String>,
-
-    /// An optional info message that, when set, should be shown to the user, in
-    /// the form of a popup.
-    info_message: Option<String>,
-
-    /// Current scroll index used for navigating through scrollable content in a
-    /// popup.
-    popup: Popup,
+    /// A popupt to show info / error messages
+    popup: Option<(PopupMessageWidget, PopupMessageState)>,
 
     /// The active mode of the application, which could change how user inputs
     /// and commands are interpreted.
@@ -213,8 +204,6 @@ impl App {
             total_num_crates: Default::default(),
             input: Default::default(),
             search_results: Default::default(),
-            error_message: Default::default(),
-            info_message: Default::default(),
             popup: Default::default(),
             prompt: Default::default(),
             last_tick_key_events: Default::default(),
@@ -328,14 +317,8 @@ impl App {
             Action::Resize(w, h) => self.resize(tui, (w, h))?,
             Action::Tick => self.tick(),
             Action::StoreTotalNumberOfCrates(n) => self.store_total_number_of_crates(n),
-            Action::ScrollUp if self.mode == Mode::Popup => self.popup.scroll_previous(),
-            Action::ScrollDown if self.mode == Mode::Popup => self.popup.scroll_next(),
-            Action::ScrollUp if self.mode == Mode::Summary => self.summary.scroll_previous(),
-            Action::ScrollDown if self.mode == Mode::Summary => self.summary.scroll_next(),
-            Action::ScrollUp if self.mode == Mode::Help => self.help.scroll_previous(),
-            Action::ScrollDown if self.mode == Mode::Help => self.help.scroll_next(),
-            Action::ScrollUp => self.search_results.scroll_previous(1),
-            Action::ScrollDown => self.search_results.scroll_next(1),
+            Action::ScrollUp => self.scroll_up(),
+            Action::ScrollDown => self.scroll_down(),
             Action::ScrollTop => self.search_results.scroll_to_top(),
             Action::ScrollBottom => self.search_results.scroll_to_bottom(),
             Action::ScrollCrateInfoUp => self.crate_info_scroll_previous(),
@@ -361,9 +344,9 @@ impl App {
             Action::ToggleShowCrateInfo => self.toggle_show_crate_info(),
             Action::UpdateCurrentSelectionCrateInfo => self.update_current_selection_crate_info(),
             Action::ShowFullCrateInfo => self.show_full_crate_details(),
-            Action::ShowErrorPopup(ref err) => self.set_error_flag(err.clone()),
-            Action::ShowInfoPopup(ref info) => self.set_info_flag(info.clone()),
-            Action::ClosePopup => self.clear_error_and_info_flags(),
+            Action::ShowErrorPopup(ref err) => self.show_error_popup(err.clone()),
+            Action::ShowInfoPopup(ref info) => self.show_info_popup(info.clone()),
+            Action::ClosePopup => self.close_popup(),
             Action::ToggleSortBy { reload, forward } => self.toggle_sort_by(reload, forward)?,
             Action::ClearTaskDetailsHandle(ref id) => {
                 self.clear_task_details_handle(uuid::Uuid::parse_str(id)?)?
@@ -452,6 +435,32 @@ impl App {
 
     fn quit(&mut self) {
         self.mode = Mode::Quit
+    }
+
+    fn scroll_up(&mut self) {
+        match self.mode {
+            Mode::Popup => {
+                if let Some((_, popup_state)) = &mut self.popup {
+                    popup_state.scroll_up();
+                }
+            }
+            Mode::Summary => self.summary.scroll_previous(),
+            Mode::Help => self.help.scroll_previous(),
+            _ => self.search_results.scroll_previous(1),
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        match self.mode {
+            Mode::Popup => {
+                if let Some((_, popup_state)) = &mut self.popup {
+                    popup_state.scroll_down();
+                }
+            }
+            Mode::Summary => self.summary.scroll_next(),
+            Mode::Help => self.help.scroll_next(),
+            _ => self.search_results.scroll_next(1),
+        }
     }
 
     fn increment_page(&mut self) {
@@ -595,24 +604,28 @@ impl App {
         Ok(())
     }
 
-    fn set_error_flag(&mut self, err: String) {
-        error!("Error: {err}");
-        self.error_message = Some(err);
+    fn show_error_popup(&mut self, message: String) {
+        error!("Error: {message}");
+        self.popup = Some((
+            PopupMessageWidget::new("Error".into(), message),
+            PopupMessageState::default(),
+        ));
         self.last_mode = self.mode;
         self.mode = Mode::Popup;
     }
 
-    fn set_info_flag(&mut self, info: String) {
+    fn show_info_popup(&mut self, info: String) {
         info!("Info: {info}");
-        self.info_message = Some(info);
+        self.popup = Some((
+            PopupMessageWidget::new("Info".into(), info),
+            PopupMessageState::default(),
+        ));
         self.last_mode = self.mode;
         self.mode = Mode::Popup;
     }
 
-    fn clear_error_and_info_flags(&mut self) {
-        self.error_message = None;
-        self.info_message = None;
-        self.popup.reset();
+    fn close_popup(&mut self) {
+        self.popup = None;
         self.mode = if self.last_mode.is_popup() {
             Mode::Search
         } else {
@@ -986,11 +999,8 @@ impl StatefulWidget for AppWidget {
                 .render(table, buf);
         }
 
-        if let Some(err) = &state.error_message {
-            PopupMessageWidget::new("Error", err).render(area, buf, &mut state.popup);
-        }
-        if let Some(info) = &state.info_message {
-            PopupMessageWidget::new("Info", info).render(area, buf, &mut state.popup);
+        if let Some((popup, popup_state)) = &mut state.popup {
+            popup.render(area, buf, popup_state);
         }
     }
 }

--- a/src/widgets/popup_message.rs
+++ b/src/widgets/popup_message.rs
@@ -1,66 +1,68 @@
 use itertools::Itertools;
-use ratatui::{layout::Flex, prelude::*, widgets::*};
+use ratatui::{
+    layout::Flex,
+    prelude::*,
+    widgets::{block::*, *},
+};
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct Popup {
+pub struct PopupMessageState {
     scroll: usize,
 }
 
-impl Popup {
-    pub fn scroll_previous(&mut self) {
+impl PopupMessageState {
+    pub fn scroll_up(&mut self) {
         self.scroll = self.scroll.saturating_sub(1)
     }
 
-    pub fn scroll_next(&mut self) {
+    pub fn scroll_down(&mut self) {
         self.scroll = self.scroll.saturating_add(1)
     }
 
-    pub fn reset(&mut self) {
+    pub fn scroll_top(&mut self) {
         self.scroll = 0;
     }
 }
 
-pub struct PopupMessageWidget<'a> {
-    title: &'a str,
-    message: &'a str,
+#[derive(Debug, Clone)]
+pub struct PopupMessageWidget {
+    title: String,
+    message: String,
 }
 
-impl<'a> PopupMessageWidget<'a> {
-    pub fn new(title: &'a str, message: &'a str) -> Self {
+impl PopupMessageWidget {
+    pub fn new(title: String, message: String) -> Self {
         Self { title, message }
     }
 }
 
-impl StatefulWidget for PopupMessageWidget<'_> {
-    type State = Popup;
+impl StatefulWidget for &PopupMessageWidget {
+    type State = PopupMessageState;
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let [center] = Layout::horizontal([Constraint::Percentage(50)])
             .flex(Flex::Center)
             .areas(area);
 
-        let message = textwrap::wrap(self.message, center.width as usize)
+        let message = textwrap::wrap(&self.message, center.width as usize)
             .iter()
             .map(|s| Line::from(s.to_string()))
             .collect_vec();
-        let height = message.len();
-        state.scroll = state.scroll.min(height.saturating_sub(1));
-
-        let [center] = Layout::vertical([Constraint::Length(height as u16 + 3)])
+        let line_count = message.len();
+        let [center] = Layout::vertical([Constraint::Length(line_count as u16 + 3)])
             .flex(Flex::Center)
             .areas(center);
-        Clear.render(center, buf);
 
-        Paragraph::new(self.message)
-            .block(
-                Block::bordered()
-                    .border_style(Color::DarkGray)
-                    .title(block::Title::from(self.title))
-                    .title(
-                        block::Title::from(Line::from(vec!["ESC".bold(), " to close".into()]))
-                            .position(block::Position::Bottom)
-                            .alignment(Alignment::Right),
-                    ),
-            )
+        state.scroll = state.scroll.min(line_count.saturating_sub(1));
+        let instruction = Title::from(vec!["Esc".bold(), " to close".into()])
+            .position(Position::Bottom)
+            .alignment(Alignment::Right);
+        let block = Block::bordered()
+            .border_style(Color::DarkGray)
+            .title(self.title.clone())
+            .title(instruction);
+        Clear.render(center, buf);
+        Paragraph::new(self.message.clone())
+            .block(block)
             .wrap(Wrap { trim: false })
             .scroll((state.scroll as u16, 0))
             .render(center, buf);


### PR DESCRIPTION
- store the message in the popup rather than in the app state
- make the popup an Option<(PopupMessageWidget, PopupMessageState)>
  rather than having separate error_message and info_message fields
- rename some methods to what they actually do rather than what Action
  they are associated with
