### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/ratatui-org/crates-tui/compare/v0.1.2...v0.1.3) - 2024-02-09
+
+### Other
+- Remove musl automated build
+
 ## [0.1.2](https://github.com/ratatui-org/crates-tui/compare/v0.1.1...v0.1.2) - 2024-02-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "crates-tui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "better-panic",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-tui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A TUI for crates.io"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `crates-tui`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/ratatui-org/crates-tui/compare/v0.1.2...v0.1.3) - 2024-02-09

### Other
- Remove musl automated build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).