### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/ratatui-org/crates-tui/compare/v0.1.3...v0.1.4) - 2024-02-09
+
+### Fixed
+- version string
+
 ## [0.1.3](https://github.com/ratatui-org/crates-tui/compare/v0.1.2...v0.1.3) - 2024-02-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "crates-tui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "better-panic",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-tui"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A TUI for crates.io"
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use tracing::level_filters::LevelFilter;
 
 const VERSION_MESSAGE: &str = concat!(
     env!("CARGO_PKG_VERSION"),
-    "-",
+    " ",
     env!("VERGEN_GIT_DESCRIBE"),
     " (",
     env!("VERGEN_BUILD_DATE"),
@@ -21,9 +21,7 @@ pub fn version() -> String {
         "\
 {VERSION_MESSAGE}
 
-Authors: {author}
-
-"
+Authors: {author}"
     )
 }
 


### PR DESCRIPTION
## 🤖 New release
* `crates-tui`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/ratatui-org/crates-tui/compare/v0.1.3...v0.1.4) - 2024-02-09

### Fixed
- version string
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).