### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/ratatui-org/crates-tui/compare/v0.1.4...v0.1.5) - 2024-02-09
+
+### Added
+- Show cargo copy in demo
+- Show help in demo
+- Add vhs tape
+- Better help menu with offset and UX for new users
+- Add Action::Ignore
+
+### Fixed
+- Don't update crate info when scrolling help
+- Change resolution in tape
+- Missing enter in vhs tape
+
+### Other
+- Update gitignore to only ignore log files
+- Update README.md with new demo
+- more tweaks to the demo by scrolling help
+- Tweak resolution and timing of the demo
+- Increase resolution of demo
+- Change demo to move up faster at the end
+
 ## [0.1.4](https://github.com/ratatui-org/crates-tui/compare/v0.1.3...v0.1.4) - 2024-02-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "crates-tui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "better-panic",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-tui"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A TUI for crates.io"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `crates-tui`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/ratatui-org/crates-tui/compare/v0.1.4...v0.1.5) - 2024-02-09

### Added
- Show cargo copy in demo
- Show help in demo
- Add vhs tape
- Better help menu with offset and UX for new users
- Add Action::Ignore

### Fixed
- Don't update crate info when scrolling help
- Change resolution in tape
- Missing enter in vhs tape

### Other
- Update gitignore to only ignore log files
- Update README.md with new demo
- more tweaks to the demo by scrolling help
- Tweak resolution and timing of the demo
- Increase resolution of demo
- Change demo to move up faster at the end
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).