### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/ratatui-org/crates-tui/compare/v0.1.5...v0.1.6) - 2024-02-11
+
+### Added
+- refactor app.rs ([#21](https://github.com/ratatui-org/crates-tui/pull/21))
+- Increase spacing between top and bottom in summary
+
+### Fixed
+- version string even without git ([#24](https://github.com/ratatui-org/crates-tui/pull/24))
+
+### Other
+- Add AUR instructions ([#22](https://github.com/ratatui-org/crates-tui/pull/22))
+
 ## [0.1.5](https://github.com/ratatui-org/crates-tui/compare/v0.1.4...v0.1.5) - 2024-02-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "crates-tui"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "better-panic",
  "cfg-if",
@@ -725,9 +725,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-tui"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A TUI for crates.io"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `crates-tui`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/ratatui-org/crates-tui/compare/v0.1.5...v0.1.6) - 2024-02-11

### Added
- refactor app.rs ([#21](https://github.com/ratatui-org/crates-tui/pull/21))
- Increase spacing between top and bottom in summary

### Fixed
- version string even without git ([#24](https://github.com/ratatui-org/crates-tui/pull/24))

### Other
- Add AUR instructions ([#22](https://github.com/ratatui-org/crates-tui/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).