### PR TITLE
fix: version string even without git

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,21 +5,23 @@ use serde::Serialize;
 use serde_with::{serde_as, skip_serializing_none, NoneAsEmptyString};
 use tracing::level_filters::LevelFilter;
 
-const VERSION_MESSAGE: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    "-",
-    env!("VERGEN_GIT_DESCRIBE"),
-    " (",
-    env!("VERGEN_BUILD_DATE"),
-    ")"
-);
-
 pub fn version() -> String {
+    let git_describe = if env!("VERGEN_GIT_DESCRIBE") != "VERGEN_IDEMPOTENT_OUTPUT" {
+        format!("-{}", env!("VERGEN_GIT_DESCRIBE"))
+    } else {
+        "".into()
+    };
+    let version_message = format!(
+        "{}{} ({})",
+        env!("CARGO_PKG_VERSION"),
+        git_describe,
+        env!("VERGEN_BUILD_DATE"),
+    );
     let author = clap::crate_authors!();
 
     format!(
         "\
-{VERSION_MESSAGE}
+{version_message}
 
 Authors: {author}"
     )


### PR DESCRIPTION
This adds git describe information conditionally.

**With Git**

```
crates-tui 0.1.5-47c8e11 (2024-02-11)

Authors: The Ratatui Developers
```

**Without Git**

```
crates-tui 0.1.5 (2024-02-11)

Authors: The Ratatui Developers
```

Fixes #23 