### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/ratatui-org/crates-tui/compare/v0.1.6...v0.1.7) - 2024-02-12
+
+### Other
+- clippy ([#32](https://github.com/ratatui-org/crates-tui/pull/32))
+- simplify help.rs ([#27](https://github.com/ratatui-org/crates-tui/pull/27))
+- *(deps)* bump chrono from 0.4.33 to 0.4.34 ([#30](https://github.com/ratatui-org/crates-tui/pull/30))
+- *(deps)* bump ratatui from 0.26.1-alpha.1 to 0.26.1 ([#31](https://github.com/ratatui-org/crates-tui/pull/31))
+- remove the specific crossterm events ([#28](https://github.com/ratatui-org/crates-tui/pull/28))
+
 ## [0.1.6](https://github.com/ratatui-org/crates-tui/compare/v0.1.5...v0.1.6) - 2024-02-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "crates-tui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "better-panic",
  "cfg-if",
@@ -972,7 +972,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2133,7 +2133,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2159,7 +2159,7 @@ version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -2448,18 +2448,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2616,7 +2616,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-tui"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "A TUI for crates.io"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `crates-tui`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/ratatui-org/crates-tui/compare/v0.1.6...v0.1.7) - 2024-02-12

### Other
- clippy ([#32](https://github.com/ratatui-org/crates-tui/pull/32))
- simplify help.rs ([#27](https://github.com/ratatui-org/crates-tui/pull/27))
- *(deps)* bump chrono from 0.4.33 to 0.4.34 ([#30](https://github.com/ratatui-org/crates-tui/pull/30))
- *(deps)* bump ratatui from 0.26.1-alpha.1 to 0.26.1 ([#31](https://github.com/ratatui-org/crates-tui/pull/31))
- remove the specific crossterm events ([#28](https://github.com/ratatui-org/crates-tui/pull/28))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).