### PR TITLE
fix: remove unused fields

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -604,7 +604,7 @@ impl App {
         ])
         .areas(area);
 
-        SearchPageWidget::new(self.mode).render(main, buf, &mut self.search);
+        SearchPageWidget.render(main, buf, &mut self.search);
 
         self.render_prompt(prompt, buf);
         self.render_status_bar(status_bar, buf);

--- a/src/widgets/search_page.rs
+++ b/src/widgets/search_page.rs
@@ -439,15 +439,9 @@ impl SearchPage {
     }
 }
 
-pub struct SearchPageWidget {
-    pub mode: Mode,
-}
+pub struct SearchPageWidget;
 
 impl SearchPageWidget {
-    pub fn new(mode: Mode) -> Self {
-        Self { mode }
-    }
-
     fn render_crate_info(&self, area: Rect, buf: &mut Buffer, state: &mut SearchPage) {
         if let Some(ci) = state.crate_response.lock().unwrap().clone() {
             CrateInfoTableWidget::new(ci).render(area, buf, &mut state.crate_info);

--- a/src/widgets/search_results.rs
+++ b/src/widgets/search_results.rs
@@ -9,7 +9,6 @@ use crate::config;
 #[derive(Debug, Default)]
 pub struct SearchResults {
     pub crates: Vec<crates_io_api::Crate>,
-    pub versions: Vec<crates_io_api::Version>,
     pub table_state: TableState,
     pub scrollbar_state: ScrollbarState,
 }


### PR DESCRIPTION
New lint in rust 1.79.0 picks up fields that are set but not read
